### PR TITLE
existing students can now be added

### DIFF
--- a/src/components/StudentPreview.tsx
+++ b/src/components/StudentPreview.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { Flex, Heading } from '@chakra-ui/react'
+
+interface IStudentToAdd {
+  studentId: string
+  studentName: string
+}
+
+type StudentPreviewProps = {
+  studentName: string
+  studentId: string
+  selectedStudentsToAdd: IStudentToAdd[]
+  setSelectedStudentsToAdd: React.Dispatch<React.SetStateAction<IStudentToAdd[]>>
+}
+
+const StudentPreview: React.FC<StudentPreviewProps> = ({
+  studentName,
+  studentId,
+  selectedStudentsToAdd,
+  setSelectedStudentsToAdd,
+}) => {
+  const [isSelected, setIsSelected] = React.useState(false)
+
+  const selectHandler = () => {
+    setIsSelected(true)
+    const updatedStudentsToAdd = [...selectedStudentsToAdd, { studentId, studentName }]
+    setSelectedStudentsToAdd(updatedStudentsToAdd)
+  }
+
+  return (
+    <Flex
+      align="center"
+      justify="space-between"
+      padding="10px"
+      onClick={selectHandler}
+      backgroundColor={isSelected ? 'aqua' : 'null'}
+    >
+      <Heading as="h3" size="md">
+        {studentName}
+      </Heading>
+    </Flex>
+  )
+}
+
+export default StudentPreview

--- a/src/interfaces and types/IStudentGroup.tsx
+++ b/src/interfaces and types/IStudentGroup.tsx
@@ -3,7 +3,7 @@ export interface IStudentGroup {
   students: IStudent[]
 }
 
-interface IStudent {
+export interface IStudent {
   studentName: string
   studentId: string
 }


### PR DESCRIPTION
only students who are not in the studentGroup are shown in the list of existing students that can be added
aqua color currently used is temporary
Had to use a loop within a loop to check which students are already in the class to properly display existing kids who can be added (without doubling students).  I don't think there's a way around it, but I could be wrong.